### PR TITLE
Fixed "Default argument value is mutable" for load_models(..).

### DIFF
--- a/peewee_migrate/router.py
+++ b/peewee_migrate/router.py
@@ -269,7 +269,10 @@ def load_models(module):
     )}
 
 
-def _import_submodules(package, passed=set()):
+def _import_submodules(package, passed=None):
+    if not passed:
+        passed = set()
+
     if isinstance(package, str):
         package = import_module(package)
 


### PR DESCRIPTION
load_models is executed only once with the correct result
```
Python 3.6.3 (default, Oct  3 2017, 21:45:48) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> from peewee_migrate.router import load_models
>>> 
>>> load_models('tests.test_autodiscover')
{<Model: Object2>, <Model: Object1>, <Model: Model3>, <Model: Object1>, <Model: Model1>, <Model: Object3>, <Model: Object3>, <Model: BaseModel>, <Model: Model2>, <Model: BaseModel>, <Model: Object2>, <Model: Model2>}
>>> 
>>> load_models('tests.test_autodiscover')
set()
>>>
```
I fixed the default assignment of passed in router._import_submodules.
